### PR TITLE
fix: can't get focus when Safari is foreground app on macOS Sequoia 15.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -25,7 +25,7 @@ jobs:
     - name: Install Linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo add-apt-repository universe
+        # https://github.com/tauri-apps/tauri/issues/9662
         sudo apt-get update
         sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install Linux dependencies
       if: matrix.os == 'ubuntu-latest'
       run: |
+        sudo add-apt-repository universe
         sudo apt-get update
         sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4470,6 +4470,7 @@ dependencies = [
  "tantivy",
  "tauri",
  "tauri-build",
+ "tauri-nspanel",
  "tauri-plugin-positioner",
  "tempfile",
  "tiktoken-rs",
@@ -4964,6 +4965,22 @@ dependencies = [
  "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-nspanel"
+version = "0.0.0"
+source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v1#d619c5581b064fd48a9b5a6a5e042fb29ddb52a4"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.0",
+ "core-graphics 0.24.0",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "tauri",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,6 +14,7 @@ tauri-build = { version = "1.2", features = [] }
 
 [dependencies]
 tauri = { version = "1.8.1", features = [ "window-center", "window-set-size", "global-shortcut", "macos-private-api", "process-command-api", "shell-open", "system-tray", "updater", "window-hide"] }
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v1" }
 tauri-plugin-positioner = "1.0.4"
 
 serde = { version = "1.0", features = ["derive"] }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1157,8 +1157,7 @@ pub fn spotlight_update_shortcut(
         settings.activation_shortcut = Some(shortcut.clone());
         state.store.settings_save(settings);
     });
-    let window = app.get_window("main").unwrap();
-    spotlight::register_shortcut(&window, &shortcut.to_macos_shortcut()).unwrap();
+    spotlight::register_shortcut(app.clone(), &shortcut.to_macos_shortcut()).unwrap();
 }
 
 #[tauri::command]
@@ -1180,6 +1179,5 @@ pub fn spotlight_get_shortcut(state: tauri::State<'_, SharedState>) -> Shortcut 
 #[tauri::command]
 #[tracing::instrument(skip(app))]
 pub fn spotlight_hide(app: tauri::AppHandle) {
-    let window = app.get_window("main").unwrap();
-    spotlight::hide(&window).unwrap();
+    spotlight::hide(&app).unwrap();
 }

--- a/src-tauri/src/serve.rs
+++ b/src-tauri/src/serve.rs
@@ -88,6 +88,7 @@ pub async fn serve<A: tauri::Assets>(context: tauri::Context<A>, db_path: String
             commands::spotlight_get_shortcut,
             commands::spotlight_hide,
         ])
+        .plugin(tauri_nspanel::init())
         .setup(move |app| {
             app.set_activation_policy(tauri::ActivationPolicy::Accessory);
 
@@ -123,7 +124,8 @@ pub async fn serve<A: tauri::Assets>(context: tauri::Context<A>, db_path: String
                     })
             });
             spotlight::init(&window).unwrap();
-            spotlight::register_shortcut(&window, &shortcut.to_macos_shortcut()).unwrap();
+            spotlight::register_shortcut(app.handle().clone(), &shortcut.to_macos_shortcut())
+                .unwrap();
 
             Ok(())
         })


### PR DESCRIPTION
Replaces custom spotlight.rs with [tauri-nspanel plugin](https://github.com/ahkohd/tauri-nspanel) to convert window to NSPanel. 

This allows NSWindowStyleMaskNonActivatingPanel support, fixing window focus behavior on macOS Sequoia 15.2 when Safari is the active application. 

🙏 @ahkohd

this takes us a step backwards for Linux support, for the moment 😔