### PR TITLE
Fix missing preventDefault call

### DIFF
--- a/src/panels/meta.tsx
+++ b/src/panels/meta.tsx
@@ -28,7 +28,7 @@ function getMeta(stack: Stack, item: Item, content: Content): MetaValue[] {
       value: (
         <a
           onClick={(e) => {
-            e.preventDefault;
+            e.preventDefault();
             invoke("store_new_note", {
               stackId: null,
               content: item.id,


### PR DESCRIPTION
## Summary
- stop default link behavior when creating a new note from the Meta panel

## Testing
- `cargo test -q` *(fails: failed to fetch git dependency)*