### PR TITLE
fix(docs): typo in v0.7.2 changelog

### DIFF
--- a/changes/v0.7.2.md
+++ b/changes/v0.7.2.md
@@ -3,7 +3,7 @@ This releases begins to improve basic UX around Stacks
 
 Features:
 
-- A new action has been added for Stack: command-Enter, which copies all content in the stack, seperated by new lines
+- A new action has been added for Stack: command-Enter, which copies all content in the stack, separated by new lines
 - When editing an item within a Stack, the new version replaces the old version. The old version is still preserved in global stack. A link is now create between the new and old items: this link isn't visible yet though
 - The light / dark theme now defaults to the user's system's preference
 - We're now generating builds for Intel Macs! (for Toby).


### PR DESCRIPTION
## Summary
- fix spelling of "separated" in `changes/v0.7.2.md`

## Testing
- `git status --short`